### PR TITLE
LOG_DICT_CONFIG for custom logging

### DIFF
--- a/scrapy/utils/log.py
+++ b/scrapy/utils/log.py
@@ -87,7 +87,8 @@ def configure_logging(settings=None, install_root_handler=True):
     observer = twisted_log.PythonLoggingObserver('twisted')
     observer.start()
 
-    dictConfig(DEFAULT_LOGGING)
+    dictConfig(settings.get('LOG_DICT_CONFIG', DEFAULT_LOGGING))
+
 
     if isinstance(settings, dict) or settings is None:
         settings = Settings(settings)


### PR DESCRIPTION
Add LOG_DICT_CONFIG option to achive ability add custom logging. For example, for `colorlog.ColoredFormatter`